### PR TITLE
Alacon progression expansions rework

### DIFF
--- a/content/expansion-guide/classic/_index.en.md
+++ b/content/expansion-guide/classic/_index.en.md
@@ -4,9 +4,99 @@ weight: 1
 description: Learn more about what to expect when The Heroes' Journey releases
 ---
 
-Classic introduces zones that released with EverQuest. In The Heroes Journey, here's a list of things worth noting about Classic that are unique to other servers:
+### Classic introduces zones that released with EverQuest. In The Heroes Journey, here's a list of things worth noting about Classic that are unique to other servers:
 
-- Iksar and Vah Shir are unlocked
-- Berserker and Beastlord are unlocked
-- Kunark zones of cabeast, cabwest, fieldofbone, kurn, lakeofillomen, swampofnohope and warslikswood are released early to accomodate Iksars
-- Luclin zones of sharvahl, hollowshade, paludal, and shadeweaver are released early to accomodate Vah Shir
+- Iksar and Vah Shir unlocked, along with starting and quest zones in their respective expansions.
+- Berserker and Beastlord are unlocked.
+
+{{<details title="Classic zones">}}
+  - Ak'Anon
+  - Befallen
+  - Blackburrow
+  - Castle Mistmoore
+  - Clan Runnyeye
+  - Commonlands
+  - Crushbone
+  - Dagnor's Cauldron
+  - East Karana
+  - Erud's Crossing
+  - Erudin
+  - Erudin Palace
+  - Estate of Unrest
+  - Everfrost Peaks
+  - Felwithe
+  - Freeport Sewers
+  - Freeport
+  - Gorge of King Xorbb
+  - Greater Faydark
+  - Grobb
+  - Halas
+  - High Keep
+  - Highpass Hold
+  - Innothule Swamp
+  - Kaladim
+  - Kedge Keep
+  - Kithicor Forest
+  - Lake Rathetear
+  - Lavastorm Mountains
+  - Lesser Faydark
+  - Lower Guk
+  - Misty Thicket
+  - Nagafen's Lair
+  - Najena
+  - Nektulos Forest
+  - Neriak
+  - North Karana
+  - North Ro
+  - Ocean of Tears
+  - Oggok
+  - Paineel
+  - Permafrost Keep
+  - Plane of Fear
+  - Plane of Hate
+  - Plane of Sky
+  - Qeynos
+  - Qeynos Catacombs
+  - Qeynos Hills
+  - Rathe Mountains
+  - Rivervale
+  - Solusek's Eye
+  - South Karana
+  - South Ro
+  - Steamfont Mountains
+  - Surefall Glade
+  - Temple of Cazic-Thule
+  - The Feerrott
+  - Toxxulia Forest
+  - Upper Guk
+  - West Karana
+{{</details>}}
+{{<details title="Kunark zones (Iksar starting areas)">}}
+ - Cabilis East
+ - Cabilis West
+ - Field Of Bone
+ - Kurns Tower
+ - Lake of Ill Omen
+ - Swamp of No Hope
+ - Warslik's Woods
+{{</details>}}
+{{<details title="Luclin zones (Vah Shir starting areas)">}}
+ - Hollowshade Moor
+ - Paludal Caverns
+ - Shadeweaver's Thicket
+ - Shar Vahl
+{{</details>}}
+
+# Notable bosses
+ ## Classic Bosses to kill for Kunark/Legacy of Ykesha Unlock
+ {{<details title="Lord Nagafen">}}
+ Found in Soluseks Eye, this is a Dragon that will challenge you with his Fire Breath attack.
+ {{</details>}}
+ {{<details title="Lady Vox">}}
+ Found in Permafrost, Lady Vox is a challenging dragon fight to not only get to, but also compete with her Complete Heal
+ {{</details>}}
+ ## Other bosses
+
+# Notable Quests
+
+# Notable items

--- a/content/expansion-guide/classic/_index.en.md
+++ b/content/expansion-guide/classic/_index.en.md
@@ -89,12 +89,8 @@ description: Learn more about what to expect when The Heroes' Journey releases
 
 # Notable bosses
  ## Classic Bosses to kill for Kunark/Legacy of Ykesha Unlock
- {{<details title="Lord Nagafen">}}
- Found in Soluseks Eye, this is a Dragon that will challenge you with his Fire Breath attack.
- {{</details>}}
- {{<details title="Lady Vox">}}
- Found in Permafrost, Lady Vox is a challenging dragon fight to not only get to, but also compete with her Complete Heal
- {{</details>}}
+- [Lord Nagafen](https://wiki.project1999.com/Lord_Nagafen)
+- [Lady Vox](https://wiki.project1999.com/Lady_Vox)
  ## Raid bosses
 #### Kedge Keep
 - [Phinigel Autropos](https://wiki.project1999.com/Phinigel_Autropos)

--- a/content/expansion-guide/classic/_index.en.md
+++ b/content/expansion-guide/classic/_index.en.md
@@ -95,7 +95,39 @@ description: Learn more about what to expect when The Heroes' Journey releases
  {{<details title="Lady Vox">}}
  Found in Permafrost, Lady Vox is a challenging dragon fight to not only get to, but also compete with her Complete Heal
  {{</details>}}
- ## Other bosses
+ ## Raid bosses
+#### Kedge Keep
+- [Phinigel Autropos](https://wiki.project1999.com/Phinigel_Autropos)
+#### Plane of Sky
+##### [P99 Guide to Plane of Sky](https://wiki.project1999.com/Plane_of_Sky)
+- [Protector of Sky](https://wiki.project1999.com/Protector_of_Sky)
+- [Noble Dojorn](https://wiki.project1999.com/Noble_Dojorn)
+- [Gorgalosk](https://wiki.project1999.com/Gorgalosk)
+- [Keeper of Souls](https://wiki.project1999.com/Keeper_of_Souls)
+- [Overseer of Air](https://wiki.project1999.com/Overseer_of_Air)
+- [The Spiroc Lord](https://wiki.project1999.com/The_Spiroc_Lord)
+- [Bazzt Zzzt](https://wiki.project1999.com/Bazzt_Zzzt)
+- [Sister of the Spire](https://wiki.project1999.com/Sister_of_the_Spire)
+- [The Hand of Veeshan](https://wiki.project1999.com/The_Hand_of_Veeshan)
+- [Eye of Veeshan](https://wiki.project1999.com/Eye_of_Veeshan)
+#### Plane of Hate
+- [Maestro of Rancor](https://wiki.project1999.com/Maestro_of_Rancor)
+- [Innoruuk](https://wiki.project1999.com/Innoruuk_(God))
+#### Plane of Fear
+- [Cazic Thule](https://wiki.project1999.com/Cazic_Thule_(God))
+- [a Dracoliche](https://wiki.project1999.com/Dracoliche)
+## Other bosses by level
+#### 10-20
+
+#### 20-30
+
+#### 30-40
+- [King Xorbb](https://wiki.project1999.com/King_Xorbb)
+- [an Evil Eye](https://wiki.project1999.com/An_Evil_Eye_(Lower_Guk))
+#### 40-50+
+
+
+
 
 # Notable Quests
 

--- a/content/expansion-guide/kunark/_index.en.md
+++ b/content/expansion-guide/kunark/_index.en.md
@@ -55,3 +55,44 @@ In order to access Kunark content, you must finish the [progression requirements
 -  Stonebrunt Mountains
 -  Veksar
 {{</details>}}
+
+# Notable bosses
+ ## Bosses to kill for Velious Unlock
+- [Severilous](https://wiki.project1999.com/Severilous)
+- [Talendor](https://wiki.project1999.com/Talendor)
+- [Gorenaire](https://wiki.project1999.com/Gorenaire)
+- [Trakanon](https://wiki.project1999.com/Trakanon)
+ ## Raid bosses
+#### Chardok
+- [Prince Selrach Di'zok](https://wiki.project1999.com/Prince_Selrach_Di%27zok)
+- [Overking Bathezid](https://wiki.project1999.com/Overking_Bathezid)
+- [Queen Velazul Di'zok](https://wiki.project1999.com/Queen_Velazul_Di%27zok)
+#### Karnor's Castle
+- [Venril Sathir](https://wiki.project1999.com/Venril_Sathir)
+#### Timorous Deep
+- [Faydedar](https://wiki.project1999.com/Faydedar)
+#### Veeshan's Peak
+- [Druushk](https://wiki.project1999.com/Druushk)
+- [Hoshkar](https://wiki.project1999.com/Hoshkar)
+- [Nexona](https://wiki.project1999.com/Nexona)
+- [Phara Dar](https://wiki.project1999.com/Phara_Dar)
+- [Silverwing](https://wiki.project1999.com/Silverwing)
+- [Xygoz](https://wiki.project1999.com/Xygoz)
+
+## Other bosses by level
+#### 10-20
+
+#### 20-30
+
+#### 30-40
+
+#### 40-50
+
+#### 50-60
+
+
+
+
+# Notable Quests
+[Epic Quests](\equipment-guide\epics)
+# Notable items

--- a/content/expansion-guide/kunark/_index.en.md
+++ b/content/expansion-guide/kunark/_index.en.md
@@ -16,3 +16,42 @@ In order to access Kunark content, you must finish the [progression requirements
 - Legacy of Ykesha gear was reduced to put it more in line with Kunark era loot
 - Charms are obtainable in Legacy of Ykesha zones. (They are not amazing, but you can fill the slot now at least)
 - You can view items and NPCs found in Kunark inside the [ret allaclone](<https://retributioneq.com/allaclone/?a=zone_era&era=kunark>). This is up to date and in sync with the latest on THJ.
+
+{{<details title="Kunark zones">}}
+-  Burning Wood
+-  Chardok
+-  City of Mist
+-  Dalnir
+-  Dreadlands
+-  Emerald Jungle
+-  Firiona Vie
+-  Frontier Mountains
+-  Howling Stones (Charasis)
+-  Kaesora
+-  Karnor's Castle
+-  Kurn's Tower
+-  Mines of Nurga
+-  Old Sebilis
+-  Skyfire Mountains
+-  Swamp of No Hope
+-  Temple of Droga
+-  The Overthere
+-  Timorous Deep
+-  Trakanon's Teeth
+-  Veeshan's Peak
+{{</details>}}
+
+{{<details title="Legacy of Ykesha zones">}}
+-  Crypt of Nadox
+-  Dulak's Harbor
+-  Gulf of Gunthak
+-  Hate's Fury, The Scorned Maiden
+-  Torgiran Mines
+{{</details>}}
+
+{{<details title="Other zones">}}
+-  ChardokB (Halls of Betrayal)
+-  Jaggedpine Forest
+-  Stonebrunt Mountains
+-  Veksar
+{{</details>}}

--- a/content/expansion-guide/velious/_index.en.md
+++ b/content/expansion-guide/velious/_index.en.md
@@ -12,3 +12,25 @@ In order to access Velious content, you must finish the [progression requirement
 - No new AAs are introduced in Velious
 - Sleeper's Key is required in order to access Sleeper's Tomb via the quest given by Jaled Dar`s Shade. Check the [progression page](/progression/) for more information.
 - Plane of Mischief is closer to the 2.0 version where Bristlebane and other creatures are a significant threat and drop noteworthy loot
+
+
+{{<details title="Velious zones">}}
+-  Cobalt Scar
+-  Crystal Caverns
+-  Dragon Necropolis
+-  Eastern Wastes
+-  Iceclad Ocean
+-  Icewell Keep
+-  Kael Drakkal
+-  Plane of Growth
+-  Plane of Mischief
+-  Siren's Grotto
+-  Skyshrine
+-  Sleeper's Tomb
+-  Temple of Veeshan
+-  Thurgadin
+-  Tower of Frozen Shadow
+-  Velketor's Labyrinth
+-  Wakening Land
+-  Western Wastes
+{{</details>}}

--- a/content/progression.md
+++ b/content/progression.md
@@ -7,15 +7,14 @@ description: Progression guide through the heroes journey.
 
 ![Progression](/images/progression.webp)
 
-Progression is broken into expansions, with key mobs needing to be killed to unlock the next.
+Progression is broken into expansions, defeating key bosses allows account-wide progression.
+Successfully defeating a boss will cause an NPC to spawn, hailing that NPC is required to progress.
 
 # Classic
+#### Unlocked 12/16/2024
+[Full Guide to Classic](/expansion-guide/classic/)
 
-{{<details title="List of Classic Zones">}}
-Not yet available
-{{</details>}}
-
-## Classic Bosses to kill for Kunark/Legacy of Ykesha Unlock
+### Kill the following bosses to progress:
 {{<details title="Lord Nagafen">}}
 Found in Soluseks Eye, this is a Dragon that will challenge you with his Fire Breath attack.
 {{</details>}}
@@ -24,89 +23,42 @@ Found in Permafrost, Lady Vox is a challenging dragon fight to not only get to, 
 {{</details>}}
 
 
-## Kunark / Legacy of Ykesha
-The following zones and epic quests are now unlocked.
-{{<details title="Kunark zones">}}
--  Burning Wood
--  Chardok
--  City of Mist
--  Dalnir
--  Dreadlands
--  Emerald Jungle
--  Firiona Vie
--  Frontier Mountains
--  Howling Stones (Charasis)
--  Kaesora
--  Karnor's Castle
--  Kurn's Tower
--  Mines of Nurga
--  Old Sebilis
--  Skyfire Mountains
--  Swamp of No Hope
--  Temple of Droga
--  The Overthere
--  Timorous Deep
--  Trakanon's Teeth
--  Veeshan's Peak
-{{</details>}}
+<h1 style="background-color:DodgerBlue;">Hello World</h1>
 
-{{<details title="Legacy of Ykesha zones">}}
--  Crypt of Nadox
--  Dulak's Harbor
--  Gulf of Gunthak
--  Hate's Fury, The Scorned Maiden
--  Torgiran Mines
-{{</details>}}
-
-{{<details title="Other zones">}}
--  ChardokB (Halls of Betrayal)
--  Jaggedpine Forest
--  Stonebrunt Mountains
--  Veksar
-{{</details>}}
-
-
+# Kunark / Legacy of Ykesha
+#### Unlocked 12/16/2024
+[Full Guide to Kunark](/expansion-guide/kunark/)
+{{<expand "Hero" "..." >}}
 ## Kill the following bosses to progress:
-
-{{<details title="Gorenaire">}}
+### Gorenaire
 This dragon can normally be found wandering the snow-capped mountains of the dreadlands.
-{{</details>}}
-{{<details title="Severilous">}}
+
+### Severilous
 Found wandering the North-West corner of the Emerald Jungle.
-{{</details>}}
-{{<details title="Talendor">}}
+
+### Talendor
 Found wandering the northern area of Skyfire Mountains.
-{{</details>}}
-{{<details title="Trakanon">}}
+
+### Trakanon
 Hidden in the depths of Old Sebilis behind an army of Sebilite protectors.
-{{</details>}}
 
-## Velious
-The following zones are now unlocked.
-{{<details title="Velious zones">}}
--  Cobalt Scar
--  Crystal Caverns
--  Dragon Necropolis
--  Eastern Wastes
--  Iceclad Ocean
--  Icewell Keep
--  Kael Drakkal
--  Plane of Growth
--  Plane of Mischief
--  Siren's Grotto
--  Skyshrine
--  Sleeper's Tomb
--  Temple of Veeshan
--  Thurgadin
--  Tower of Frozen Shadow
--  Velketor's Labyrinth
--  Wakening Land
--  Western Wastes
-{{</details>}}
+{{</expand>}}
 
-## Kill the following bosses to progress.:
+{{<expand "Explorer" "..." >}}
+## Gather the following items:
+Elemental Binder
+Djarn's Amethyst Ring
+Crown of the Froglok Kings
+Scalp of the Ghoul Lord
 
-To unlock Luclin, you must kill:
+{{</expand>}}
+
+
+
+# Velious
+#### Unlocked 12/27/2024
+[Full Guide to Velious](/expansion-guide/velious/)
+### Kill the following bosses to progress:
 {{<details title="Wuoshi">}}
 This lady dragon guards the Dragon Portal in the Wakening Lands. Casts Ceticious Cloud ((poison) 600 PB AE DD and 8-second stun) and Dragon Roar ((magic) PB AE 18-second fear).
 {{</details>}}
@@ -131,16 +83,27 @@ One of the 4 warders in Sleepers Tomb.
 {{<details title="Ventani the Warder">}}
 One of the 4 warders in Sleepers Tomb.
 {{</details>}}
+# Luclin
+#### Unlocked 12/27/2024
+[Full Guide to Velious](/expansion-guide/velious/)
 
-## Luclin
+### Kill the following bosses to progress:
 
-To unlock PoP, you must kill:
-
-- Thought Horror Fiend
-- Grief Veneficus
-- Insanity Crawler
-- Xerkizhh the Creator
-- Emporer Ssraeshza
+{{<details title="Thought Horror Fiend">}}
+Location
+{{</details>}}
+{{<details title="Grieg Veneficus">}}
+Greig's end
+{{</details>}}
+{{<details title="lInsanity Crawler">}}
+Akheva ruins
+{{</details>}}
+{{<details title="Xerkizhh the Creator">}}
+SSRA temple
+{{</details>}}
+{{<details title="Emporer Ssraeshza">}}
+SSRA temple
+{{</details>}}
 
 ## Planes of Power
 

--- a/content/progression.md
+++ b/content/progression.md
@@ -7,21 +7,36 @@ description: Progression guide through the heroes journey.
 
 ![Progression](/images/progression.webp)
 
-Progression is broken into expansions, defeating key bosses allows account-wide progression.
-Successfully defeating a boss will cause an NPC to spawn, hailing that NPC is required to progress.
+### Progression is broken into expansions, released in (mostly) the same order, with other zones added to supplement user experience.
+### Progression is account wide, you only have to complete these tasks once per account for all characters to have access.
+
+## There are 2 routes to account progression as listed below.
+
+### Hero
+- Kill specific bosses.
+
+### Adventurer
+- Gather specific items.
+
 
 # Classic
 #### Unlocked 12/16/2024
 [Full Guide to Classic](/expansion-guide/classic/)
 
-### Kill the following bosses to progress:
-{{<details title="Lord Nagafen">}}
+{{<expand "Hero" "..." >}}
+## Kill the following bosses to progress:
+### Lord Nagafen
 Found in Soluseks Eye, this is a Dragon that will challenge you with his Fire Breath attack.
-{{</details>}}
-{{<details title="Lady Vox">}}
+### Lady Vox
 Found in Permafrost, Lady Vox is a challenging dragon fight to not only get to, but also compete with her Complete Heal
-{{</details>}}
-
+{{</expand>}}
+{{<expand "Explorer" "..." >}}
+## Gather the following items and hand them to the NPC located in the Bazaar:
+- Elemental Binder
+- Djarn's Amethyst Ring
+- Crown of the Froglok Kings
+- Scalp of the Ghoul Lord
+{{</expand>}}
 
 <h1 style="background-color:DodgerBlue;">Hello World</h1>
 
@@ -32,24 +47,20 @@ Found in Permafrost, Lady Vox is a challenging dragon fight to not only get to, 
 ## Kill the following bosses to progress:
 ### Gorenaire
 This dragon can normally be found wandering the snow-capped mountains of the dreadlands.
-
 ### Severilous
 Found wandering the North-West corner of the Emerald Jungle.
-
 ### Talendor
 Found wandering the northern area of Skyfire Mountains.
-
 ### Trakanon
 Hidden in the depths of Old Sebilis behind an army of Sebilite protectors.
-
 {{</expand>}}
 
 {{<expand "Explorer" "..." >}}
-## Gather the following items:
-Elemental Binder
-Djarn's Amethyst Ring
-Crown of the Froglok Kings
-Scalp of the Ghoul Lord
+## Gather the following items and hand them to the NPC located in the Bazaar:
+- Mask of Secrets
+- Sebilite Scale Mask
+- Helot Skull Helm
+- Helm of Rile
 
 {{</expand>}}
 
@@ -58,52 +69,54 @@ Scalp of the Ghoul Lord
 # Velious
 #### Unlocked 12/27/2024
 [Full Guide to Velious](/expansion-guide/velious/)
-### Kill the following bosses to progress:
-{{<details title="Wuoshi">}}
-This lady dragon guards the Dragon Portal in the Wakening Lands. Casts Ceticious Cloud ((poison) 600 PB AE DD and 8-second stun) and Dragon Roar ((magic) PB AE 18-second fear).
-{{</details>}}
-{{<details title="Zlandicar">}}
-Zlandicar is one of the final members of the first brood, he has been banished to the Dragon Necropolis
-{{</details>}}
-{{<details title="Klandicar">}}
-Klandicar is another one of the few remaining first brood, he resides in the western wastes and serves as the sentinel keeping his banished cousin contained.
-{{</details>}}
-{{<details title="Lord Yelinak">}}
-Lord Yelinak is the leader of the Claws of Veeshan and one of the few remaining first brood, located in Skyshrine.
-{{</details>}}
-{{<details title="Hraasha the Warder">}}
-One of the 4 warders in Sleepers Tomb.
-{{</details>}}
-{{<details title="Nanzata the Warder">}}
-One of the 4 warders in Sleepers Tomb.
-{{</details>}}
-{{<details title="Tukaarak the Warder">}}
-One of the 4 warders in Sleepers Tomb.
-{{</details>}}
-{{<details title="Ventani the Warder">}}
-One of the 4 warders in Sleepers Tomb.
-{{</details>}}
+{{<expand "Hero" "..." >}}
+## Kill the following bosses to progress:
+## Wuoshi
+- This lady dragon guards the Dragon Portal in the Wakening Lands. Casts Ceticious Cloud ((poison) 600 PB AE DD and 8-second stun) and Dragon Roar ((magic) PB AE 18-second fear).
+## Zlandicar
+- Zlandicar is one of the final members of the first brood, he has been banished to the Dragon Necropolis
+## Klandicar
+- Klandicar is another one of the few remaining first brood, he resides in the western wastes and serves as the sentinel keeping his banished cousin contained.
+## Lord Yelinak
+- Lord Yelinak is the leader of the Claws of Veeshan and one of the few remaining first brood, located in Skyshrine.
+## 4 warders in Sleepers Tomb
+- Hraasha the Warder
+- Nanzata the Warder
+- Tukaarak the Warder
+- Ventani the Warder
+
+
+{{</expand>}}
+
+{{<expand "Explorer" "..." >}}
+## Gather the following items and hand them to the NPC located in the Bazaar:
+- TBD
+
+{{</expand>}}
+
 # Luclin
 #### Unlocked 12/27/2024
-[Full Guide to Velious](/expansion-guide/velious/)
+[Full Guide to Luclin](/expansion-guide/luclin/)
+{{<expand "Hero" "..." >}}
+## Kill the following bosses to progress:
+## Thought Horror Overfiend
+- Rolling in the deep
+## Grieg Veneficus
+- Greig's end
+## Insanity Crawler
+- Akheva ruins
+## Xerkizhh the Creator
+- SSRA temple
+## Emporer Ssraeshza
+-SSRA temple
 
-### Kill the following bosses to progress:
+{{</expand>}}
 
-{{<details title="Thought Horror Fiend">}}
-Location
-{{</details>}}
-{{<details title="Grieg Veneficus">}}
-Greig's end
-{{</details>}}
-{{<details title="lInsanity Crawler">}}
-Akheva ruins
-{{</details>}}
-{{<details title="Xerkizhh the Creator">}}
-SSRA temple
-{{</details>}}
-{{<details title="Emporer Ssraeshza">}}
-SSRA temple
-{{</details>}}
+{{<expand "Explorer" "..." >}}
+## Gather the following items and hand them to the NPC located in the Bazaar:
+- TBD
+
+{{</expand>}}
 
 ## Planes of Power
 


### PR DESCRIPTION
Updates Progression page to be a single page of info as a quick guide an pushes information to the individual expansion pages.
